### PR TITLE
feat: add media request types

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 ## Completed
 - [x] Bootstrap migration skeleton
+- [x] Port media request enums, types, and override hook
 
 ## Data Model & Storage
 - [ ] Merge Jellyseerr request entities into Jellyfin database

--- a/src/constants/media.ts
+++ b/src/constants/media.ts
@@ -1,0 +1,22 @@
+export enum MediaRequestStatus {
+    PENDING = 1,
+    APPROVED,
+    DECLINED,
+    FAILED,
+    COMPLETED
+}
+
+export enum MediaType {
+    MOVIE = 'movie',
+    TV = 'tv'
+}
+
+export enum MediaStatus {
+    UNKNOWN = 1,
+    PENDING,
+    PROCESSING,
+    PARTIALLY_AVAILABLE,
+    AVAILABLE,
+    BLACKLISTED,
+    DELETED
+}

--- a/src/hooks/useRequestOverride.ts
+++ b/src/hooks/useRequestOverride.ts
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query';
+import { MediaType } from 'constants/media';
+import type { MediaRequest } from 'types/mediaRequest';
+import type { ServiceCommonServer, ServiceCommonServerWithDetails } from 'types/service';
+
+interface OverrideStatus {
+    server?: string;
+    profile?: string;
+    rootFolder?: string;
+    languageProfile?: string;
+}
+
+const fetchServers = async (
+    type: MediaType
+): Promise<ServiceCommonServer[]> => {
+    const res = await fetch(`/api/v1/service/${type === MediaType.MOVIE ? 'radarr' : 'sonarr'}`);
+    if (!res.ok) {
+        throw new Error('Failed to fetch services');
+    }
+    return res.json();
+};
+
+const fetchServerDetails = async (
+    type: MediaType,
+    id: number
+): Promise<ServiceCommonServerWithDetails> => {
+    const res = await fetch(
+        `/api/v1/service/${type === MediaType.MOVIE ? 'radarr' : 'sonarr'}/${id}`
+    );
+    if (!res.ok) {
+        throw new Error('Failed to fetch service details');
+    }
+    return res.json();
+};
+
+const useRequestOverride = (request: MediaRequest): OverrideStatus => {
+    const { data: allServers } = useQuery({
+        queryKey: ['service', request.type],
+        queryFn: () => fetchServers(request.type)
+    });
+
+    const { data } = useQuery({
+        queryKey: ['service', request.type, request.serverId],
+        queryFn: () => fetchServerDetails(request.type, request.serverId as number),
+        enabled: !!request.serverId
+    });
+
+    if (!data || !allServers) {
+        return {};
+    }
+
+    const defaultServer = allServers.find(
+        (server) => server.is4k === request.is4k && server.isDefault
+    );
+    const activeServer = allServers.find((server) => server.id === request.serverId);
+
+    return {
+        server:
+            activeServer && request.serverId !== defaultServer?.id ?
+                activeServer.name :
+                undefined,
+        profile:
+            defaultServer?.activeProfileId !== request.profileId ?
+                data.profiles.find((profile) => profile.id === request.profileId)?.name :
+                undefined,
+        rootFolder:
+            defaultServer?.activeDirectory !== request.rootFolder ?
+                request.rootFolder :
+                undefined,
+        languageProfile:
+            request.type === MediaType.TV
+            && defaultServer?.activeLanguageProfileId !== request.languageProfileId ?
+                data.languageProfiles?.find(
+                    (profile) => profile.id === request.languageProfileId
+                )?.name :
+                undefined
+    };
+};
+
+export default useRequestOverride;

--- a/src/types/mediaRequest.ts
+++ b/src/types/mediaRequest.ts
@@ -1,0 +1,11 @@
+import { MediaType } from 'constants/media';
+
+export interface MediaRequest {
+    id: number;
+    type: MediaType;
+    is4k: boolean;
+    serverId?: number;
+    profileId?: number;
+    rootFolder?: string;
+    languageProfileId?: number;
+}

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -1,0 +1,42 @@
+export interface QualityProfile {
+    id: number;
+    name: string;
+}
+
+export interface RootFolder {
+    id: number;
+    path: string;
+}
+
+export interface Tag {
+    id: number;
+    label: string;
+}
+
+export interface LanguageProfile {
+    id: number;
+    name: string;
+}
+
+export interface ServiceCommonServer {
+    id: number;
+    name: string;
+    is4k: boolean;
+    isDefault: boolean;
+    activeProfileId: number;
+    activeDirectory: string;
+    activeLanguageProfileId?: number;
+    activeAnimeProfileId?: number;
+    activeAnimeDirectory?: string;
+    activeAnimeLanguageProfileId?: number;
+    activeTags: number[];
+    activeAnimeTags?: number[];
+}
+
+export interface ServiceCommonServerWithDetails {
+    server: ServiceCommonServer;
+    profiles: QualityProfile[];
+    rootFolders: Partial<RootFolder>[];
+    languageProfiles?: LanguageProfile[];
+    tags: Tag[];
+}


### PR DESCRIPTION
## Summary
- add media request enums and basic types
- implement request override hook with React Query
- update migration TODO

## Testing
- `npx eslint src/constants/media.ts src/types/service.ts src/types/mediaRequest.ts src/hooks/useRequestOverride.ts TODO.md`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6893b3ad025c8330b2faa6fd7a0e1f1a