### PR TITLE
feat(db): add request table migrations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -64,3 +64,9 @@ scope or tasks live in `TODO.md`.
 2. Integration tests for request workflows and *Arr communication.
 3. End‑to‑end tests for major UI flows.
 4. Load tests to validate high request volume scenarios.
+
+## Task: Create EF Core migrations
+1. Install .NET 9 SDK and the `dotnet-ef` tool.
+2. Run `dotnet ef migrations add AddRequestTables` targeting the SQLite provider project.
+3. Verify that the generated migration creates `ArrInstances`, `MediaRequests`, `RequestStatuses`, and `SeasonRequests` tables.
+4. Build the provider project to ensure the migration compiles.

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 ## Data Model & Storage
 - [x] Merge Jellyseerr request entities into Jellyfin database
 - [x] Add tables for media requests, request status, and *arr instances
-- [ ] Create EF Core migrations
+- [x] Create EF Core migrations
 - [ ] Add indexes for lookups by media, user, and status
 
 ## Backend API

--- a/jellyfin-server/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/.gitattributes
+++ b/jellyfin-server/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/.gitattributes
@@ -1,1 +1,0 @@
-JellyfinDbModelSnapshot.cs binary

--- a/jellyfin-server/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250807001339_AddRequestTables.Designer.cs
+++ b/jellyfin-server/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250807001339_AddRequestTables.Designer.cs
@@ -3,16 +3,19 @@ using System;
 using Jellyfin.Database.Implementations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Jellyfin.Server.Implementations.Migrations
+namespace Jellyfin.Database.Providers.Sqlite.Migrations
 {
     [DbContext(typeof(JellyfinDbContext))]
-    partial class JellyfinDbModelSnapshot : ModelSnapshot
+    [Migration("20250807001339_AddRequestTables")]
+    partial class AddRequestTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.7");

--- a/jellyfin-server/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250807001339_AddRequestTables.cs
+++ b/jellyfin-server/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250807001339_AddRequestTables.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Jellyfin.Database.Providers.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRequestTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ArrInstances",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Type = table.Column<int>(type: "INTEGER", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    BaseUrl = table.Column<string>(type: "TEXT", nullable: false),
+                    ApiKey = table.Column<string>(type: "TEXT", nullable: false),
+                    DateCreated = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    DateModified = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    RowVersion = table.Column<uint>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ArrInstances", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MediaRequests",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    RequestedByUserId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    TmdbId = table.Column<int>(type: "INTEGER", nullable: false),
+                    TvdbId = table.Column<int>(type: "INTEGER", nullable: true),
+                    MediaType = table.Column<int>(type: "INTEGER", nullable: false),
+                    Is4K = table.Column<bool>(type: "INTEGER", nullable: false),
+                    Status = table.Column<int>(type: "INTEGER", nullable: false),
+                    DateCreated = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    DateModified = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    RowVersion = table.Column<uint>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MediaRequests", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MediaRequests_Users_RequestedByUserId",
+                        column: x => x.RequestedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RequestStatuses",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    MediaRequestId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Status = table.Column<int>(type: "INTEGER", nullable: false),
+                    DateCreated = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    DateModified = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    RowVersion = table.Column<uint>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RequestStatuses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RequestStatuses_MediaRequests_MediaRequestId",
+                        column: x => x.MediaRequestId,
+                        principalTable: "MediaRequests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SeasonRequests",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    SeasonNumber = table.Column<int>(type: "INTEGER", nullable: false),
+                    Status = table.Column<int>(type: "INTEGER", nullable: false),
+                    MediaRequestId = table.Column<int>(type: "INTEGER", nullable: false),
+                    DateCreated = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    DateModified = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    RowVersion = table.Column<uint>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeasonRequests", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SeasonRequests_MediaRequests_MediaRequestId",
+                        column: x => x.MediaRequestId,
+                        principalTable: "MediaRequests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MediaRequests_RequestedByUserId",
+                table: "MediaRequests",
+                column: "RequestedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RequestStatuses_MediaRequestId",
+                table: "RequestStatuses",
+                column: "MediaRequestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonRequests_MediaRequestId",
+                table: "SeasonRequests",
+                column: "MediaRequestId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ArrInstances");
+
+            migrationBuilder.DropTable(
+                name: "RequestStatuses");
+
+            migrationBuilder.DropTable(
+                name: "SeasonRequests");
+
+            migrationBuilder.DropTable(
+                name: "MediaRequests");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add EF Core migration creating ArrInstances, MediaRequests, RequestStatuses, and SeasonRequests tables
- document plan for generating migrations
- check off EF Core migration task in roadmap
- treat EF Core snapshot as text by dropping binary gitattributes

## Testing
- `dotnet test tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj` *(fails: CS0120: An object reference is required for the non-static field, method, or property 'UserManager.ThrowIfInvalidUsername(string)')*

------
https://chatgpt.com/codex/tasks/task_b_6893ed8a89d48330aa42413772427949